### PR TITLE
Fix welcome message dismiss button

### DIFF
--- a/templates/admin/welcome.php
+++ b/templates/admin/welcome.php
@@ -10,12 +10,14 @@
 
 
 	<?php if ( isset($_GET['activation']) ) : ?>
-		<div class="updated notice">
+		<div class="updated notice is-dismissible kanban-welcome-notice">
 			<p><?php echo __('Thanks for using Kanban for WordPress!', 'kanban') ?></p>
-			<button type="button" class="notice-dismiss">
-				<span class="screen-reader-text"><?php echo __('Dismiss this notice.', 'kanban') ?></span>
-			</button>
 		</div>
+		<script>
+			jQuery( document.body ).on( 'click', '.kanban-welcome-notice .notice-dismiss', function() {
+				window.history.replaceState('Object', 'Title', '<?php echo esc_url( admin_url( 'admin.php?page=kanban_welcome' ) ); ?>' );
+			});
+		</script>
 	<?php endif ?>
 
 


### PR DESCRIPTION
The dismiss in the welcome message wasn't showing correct:
![image](https://cloud.githubusercontent.com/assets/5774447/13436926/e8f53cb4-dfe1-11e5-9ea0-052e7120ab38.png)
(note right top dismiss position)

and it didn't work.
This PR fixes both.
