### PR TITLE
Fix heisenbug

### DIFF
--- a/includes/class-db.php
+++ b/includes/class-db.php
@@ -961,8 +961,6 @@ abstract class Kanban_Db
 	{
 		global $wpdb;
 
-
-
 		$status_table = Kanban_Status::table_name();
 
 		$sql = "SELECT count(`id`)
@@ -1127,6 +1125,8 @@ abstract class Kanban_Db
 
 			Kanban_Option::replace($data);
 		}
+
+		return true;
 	}
 
 


### PR DESCRIPTION
Fixes a weird Heisenbug that I got locally (Corey didn't seem to get this)

```
[01-Mar-2016 19:02:23 UTC] PHP Notice:  Undefined offset: 0 in /Applications/MAMP/htdocs/co/wp-includes/plugin.php on line 925
[01-Mar-2016 19:02:23 UTC] PHP Stack trace:
[01-Mar-2016 19:02:23 UTC] PHP   1. {main}() /Applications/MAMP/htdocs/co/wp-admin/plugins.php:0
[01-Mar-2016 19:02:23 UTC] PHP   2. activate_plugin() /Applications/MAMP/htdocs/co/wp-admin/plugins.php:42
[01-Mar-2016 19:02:23 UTC] PHP   3. do_action() /Applications/MAMP/htdocs/co/wp-admin/includes/plugin.php:572
[01-Mar-2016 19:02:23 UTC] PHP   4. Kanban::on_activation() /Applications/MAMP/htdocs/co/wp-includes/plugin.php:525
[01-Mar-2016 19:02:23 UTC] PHP   5. add_action() /Applications/MAMP/htdocs/co/wp-content/plugins/kanban/kanban.php:121
[01-Mar-2016 19:02:23 UTC] PHP   6. add_filter() /Applications/MAMP/htdocs/co/wp-includes/plugin.php:458
[01-Mar-2016 19:02:23 UTC] PHP   7. _wp_filter_build_unique_id() /Applications/MAMP/htdocs/co/wp-includes/plugin.php:106
[01-Mar-2016 19:02:23 UTC] PHP Notice:  Undefined offset: 0 in /Applications/MAMP/htdocs/co/wp-includes/plugin.php on line 943
[01-Mar-2016 19:02:23 UTC] PHP Stack trace:
[01-Mar-2016 19:02:23 UTC] PHP   1. {main}() /Applications/MAMP/htdocs/co/wp-admin/plugins.php:0
[01-Mar-2016 19:02:23 UTC] PHP   2. activate_plugin() /Applications/MAMP/htdocs/co/wp-admin/plugins.php:42
[01-Mar-2016 19:02:23 UTC] PHP   3. do_action() /Applications/MAMP/htdocs/co/wp-admin/includes/plugin.php:572
[01-Mar-2016 19:02:23 UTC] PHP   4. Kanban::on_activation() /Applications/MAMP/htdocs/co/wp-includes/plugin.php:525
[01-Mar-2016 19:02:23 UTC] PHP   5. add_action() /Applications/MAMP/htdocs/co/wp-content/plugins/kanban/kanban.php:121
[01-Mar-2016 19:02:23 UTC] PHP   6. add_filter() /Applications/MAMP/htdocs/co/wp-includes/plugin.php:458
[01-Mar-2016 19:02:23 UTC] PHP   7. _wp_filter_build_unique_id() /Applications/MAMP/htdocs/co/wp-includes/plugin.php:106
```

Happened when activating the plugin..
